### PR TITLE
Fix indexedDB run dependency

### DIFF
--- a/src/Fetch.js
+++ b/src/Fetch.js
@@ -21,6 +21,7 @@ var Fetch = {
   },
 
 #if FETCH_SUPPORT_INDEXEDDB
+  // Be cautious that `onerror` may be run synchronously
   openDatabase: function(dbname, dbversion, onsuccess, onerror) {
     try {
 #if FETCH_DEBUG
@@ -68,12 +69,11 @@ var Fetch = {
         removeRunDependency('library_fetch_init');
       }
     };
+    if (isMainThread) {
+      addRunDependency('library_fetch_init');
+    }
     Fetch.openDatabase('emscripten_filesystem', 1, onsuccess, onerror);
 #endif // ~FETCH_SUPPORT_INDEXEDDB
-
-#if FETCH_SUPPORT_INDEXEDDB
-    if (typeof ENVIRONMENT_IS_FETCH_WORKER == 'undefined' || !ENVIRONMENT_IS_FETCH_WORKER) addRunDependency('library_fetch_init');
-#endif
   }
 }
 

--- a/src/Fetch.js
+++ b/src/Fetch.js
@@ -46,32 +46,24 @@ var Fetch = {
 #endif
 
   staticInit: function() {
-    var isMainThread = true;
-
 #if FETCH_SUPPORT_INDEXEDDB
     var onsuccess = (db) => {
 #if FETCH_DEBUG
       dbg('fetch: IndexedDB successfully opened.');
 #endif
       Fetch.dbInstance = db;
-
-      if (isMainThread) {
-        removeRunDependency('library_fetch_init');
-      }
+      removeRunDependency('library_fetch_init');
     };
+
     var onerror = () => {
 #if FETCH_DEBUG
       dbg('fetch: IndexedDB open failed.');
 #endif
       Fetch.dbInstance = false;
-
-      if (isMainThread) {
-        removeRunDependency('library_fetch_init');
-      }
+      removeRunDependency('library_fetch_init');
     };
-    if (isMainThread) {
-      addRunDependency('library_fetch_init');
-    }
+
+    addRunDependency('library_fetch_init');
     Fetch.openDatabase('emscripten_filesystem', 1, onsuccess, onerror);
 #endif // ~FETCH_SUPPORT_INDEXEDDB
   }

--- a/src/closure-externs/closure-externs.js
+++ b/src/closure-externs/closure-externs.js
@@ -212,13 +212,6 @@ var removeEventListener = function (type, listener) {};
  */
 var close;
 
-// Fetch.js/Fetch Worker
-
-/**
- * @suppress {undefinedVars}
- */
-var ENVIRONMENT_IS_FETCH_WORKER;
-
 // Due to the way MODULARIZE works, Closure is run on generated code that does not define _scriptDir,
 // but only after MODULARIZE has finished, _scriptDir is injected to the generated code.
 // Therefore it cannot be minified.

--- a/test/test_other.py
+++ b/test/test_other.py
@@ -12317,6 +12317,21 @@ Module['postRun'] = function() {{
     self.build(test_file('fetch/example_waitable_xhr_to_memory.c'))
     self.build(test_file('fetch/example_xhr_progress.c'))
 
+  def test_fetch_init_node(self):
+    # Make sure that `Fetch` initialises correctly under Node where
+    # IndexedDB isn't available.
+    self.set_setting('FETCH')
+    self.set_setting('EXPORTED_RUNTIME_METHODS', ['Fetch'])
+    create_file('src.c', r'''
+#include <stdio.h>
+int main() {
+  puts("ok");
+}
+''')
+    self.run_process([EMCC, 'src.c', '-sFETCH', '-sEXPORTED_RUNTIME_METHODS=["Fetch"]'])
+    ret = self.run_process(config.NODE_JS + ['a.out.js'], stdout=PIPE).stdout
+    self.assertContained('ok', ret)
+
   # Test that using llvm-nm works when response files are in use, and inputs are linked using relative paths.
   # llvm-nm has a quirk that it does not remove escape chars when printing out filenames.
   @with_env_modify({'EM_FORCE_RESPONSE_FILES': '1'})


### PR DESCRIPTION
`removeRunDependency()` should only be run after `addRunDependency()`. This is checked by an assertion in debug builds.

`Fetch.staticInit()` currently runs `addRunDependency()` _after_ calling `openDatabase()`. The method creates an XHR request with `removeRunDependency()` called asynchronously in onsuccess and onerror fallbacks. This works most of the time except when `onerror()` is called synchronously via try/catch when the request can't be created.

The first commit fixes this by creating the run dependency first. The second commit simplifies control flow a bit since the conditioning on `isMainThread` is no longer necessary.