### PR TITLE
Use locateFile in the dynamic module loader

### DIFF
--- a/src/library_dylink.js
+++ b/src/library_dylink.js
@@ -858,6 +858,7 @@ var LibraryDylink = {
         return flags.loadAsync ? Promise.resolve(libData) : libData;
       }
 
+      libFile = locateFile(libFile);
       if (flags.loadAsync) {
         return new Promise(function(resolve, reject) {
           readAsync(libFile, (data) => resolve(new Uint8Array(data)), reject);


### PR DESCRIPTION
In `loadLibData`, the path to `libFile` is passed through `locateFile` before attempting to download the data from an external source. Fixes #14502.

A test for dynamic linking with `locateFile` is added that creates the `liblib.so` side module in an external temporary directory rather than in the current directory (as with the other dynamic linking tests). The side module is linked by passing the full file path to `liblib.so`, and `locateFile` is then used to tell Emscripten at runtime where to find the side module file.

The test should only pass when the dynamic module loader is indeed using `locateFile` to locate the side module file for loading.